### PR TITLE
Leave comments on core chialisp

### DIFF
--- a/puzzles/singleton/action.clsp
+++ b/puzzles/singleton/action.clsp
@@ -10,7 +10,7 @@
 ;;        (it is persistent)
 ;;    ephemeral_state is not persistent - it's () for the first action of any new spend
 ;;        but passed from the previous action in the same spend
-;;    new_conditions will be directly aded to this puzzle's output conditions
+;;    new_conditions will be directly added to this puzzle's output conditions
 ;;    but the finalizer puzzle is able to filter them after all actions are run
 
 ;; Warning: This puzzle's finalizer likely assumes the singleton's amount is 1 (like the default one does).
@@ -34,6 +34,18 @@
         )
     )
 
+    ; Quex - You should see this example of proving multiple values in a merkle tree:
+    ; https://github.com/Chia-Network/chia_puzzles/pull/22/files#diff-6d0e3492d26b935e4814cb199105b259e72329198a9f9ec5854fefe577f3a5f7R1
+    ;
+    ; Using merkle roots like this you're likely to repeat hashes of siblings multiple times.
+    ;
+    ; You would need to reconfigure the "selector" logic however. I haven't put in the effort to think through the full
+    ; implications but your result of the recursive operation might need to basically return the valid selectors instead.
+    ; Then you can continue as you do what you do here where the solution uses the selectors as references to puzzles
+    ; in your grand proof.
+    ;
+    ; My intuition tells me that despite how complicated that sounds, it will be much more efficient on average.
+    ; It leans into the tree nature of CLVM rather than the linear nature of the existing list.
     (defun reduce_and_verify_proofs (
         MERKLE_ROOT
         puzzles
@@ -41,7 +53,7 @@
         (@ pending_selectors_and_proofs ((selector . proof) . remaining_pending_selectors_and_proofs))
     )
         (if pending_selectors_and_proofs
-            (if 
+            (if
                 (if proof
                     (= MERKLE_ROOT (simplify_merkle_proof (sha256tree (a selector puzzles)) proof))
                     ; else
@@ -71,6 +83,11 @@
         (if pending_selectors
             (run_actions
                 puzzles
+                ; If I'm not mistaken don't you need to merge_list here?
+                ; As this stands I would expect ((condition condition) (condition condition))
+                ; ...
+                ; Ah, I see you defer this responsibility to the finalizer.
+                ; The thing is, it _must_ happen so I don't think you should make developers constantly reimplement this
                 (c new_conditions current_conditions)
                 (a (a selector puzzles) (list ephemeral_and_actual_state solution))
                 remaining_selectors
@@ -83,14 +100,14 @@
             )
         )
     )
-    
+
     (a
         FINALZIER
         (list
             MERKLE_ROOT
             STATE
             (run_actions
-                puzzles                
+                puzzles
                 ()
                 (list (c () STATE))
                 (reduce_and_verify_proofs MERKLE_ROOT puzzles () selectors_and_proofs)

--- a/puzzles/singleton/finalizer.clsp
+++ b/puzzles/singleton/finalizer.clsp
@@ -3,11 +3,13 @@
 ;; The current one only re-creates the singleton, but advanced dApps could use it to create other
 ;;  conditions based on the final state - e.g., re-create the singleton's reserves or modify merkle root
 
+;; It wouldn't be the worst thing in the world to take a solution value and throw in ASSERT_MY_AMOUNT no?
 ;; Note: This finalizer assumes sets the next singleton's amount to 1.
 
 (mod (
     ACTION_LAYER_MOD_HASH
     HINT
+    ; You should leave a comment that this is a second curry on top of the first
     FINALIZER_SELF_HASH
     Merkle_Root
     Initial_State ; not used for this puzzle

--- a/puzzles/singleton/slot.clsp
+++ b/puzzles/singleton/slot.clsp
@@ -1,15 +1,19 @@
 ; slot.clsp by yakuhito
 ;; A singleton slot coin is created to store values that may be read at a later spend
 ;; To read the values, the singleton will spend the slot coin - so the values are only readable once
-;; Might be helpful to think of this as a one-time ticket 
+;; Might be helpful to think of this as a one-time ticket
 
 ;; Warning: Slots do not assure uniqueness - a double-linked sorted list structure on top is required for that
 ;;          An attacker might intentionally omit a given slot to trick the dApp that it doesn't exist
 ;;          For example, a naive handle reigstration app might be tricked into registering the same handle twice
 
+; A solution value wouldn't really be too much trouble right?
 ;; Warning 2: This puzzle assumes the controller singleton has an amount of 1.
 
 (mod (
+      ; I haven't seen comments explaining the following:
+      ; a) why this is double curried
+      ; b) what the difference between the NONCE and the VALUE_HASH is
       ; 1st curry
       SINGLETON_STRUCT ; owner/controller singleton
       NONCE ; different nonces will hold different data types
@@ -33,10 +37,12 @@
         )
     )
 
-    (list 
+    ; The singleton struct is hashes twice here, you can probably optimize this
+    (list
         (list ASSERT_MY_PARENT_ID
             (coinid parent_parent_info (singleton_full_puzzle_hash SINGLETON_STRUCT parent_inner_puzzle_hash) 1)
         )
+        ; comment about what 18 means would be nice
         (list RECEIVE_MESSAGE 18 () (singleton_full_puzzle_hash SINGLETON_STRUCT spender_inner_puzzle_hash)) ; puzzle-puzzle
     )
 )


### PR DESCRIPTION
This PR is not intended to be merged but as a vehicle for comments on the three core chialisp puzzles mentioned in the CHIP: `action.clsp`, `finalizer.clsp`, and `slot.clsp`.

The comments are relatively minor, but I do have an architectural complaint:

This puzzle rejects the paradigm of the inner/outer puzzle divide.  It straddles the divide and thus results in some consequences that the rest of the ecosystem is trying to avoid. The main problem is that there is no interoperability with existing true inner puzzles.  You can't put `p2_*` puzzles in the merkle root because they need to take this special kind of "Truthful" state which means that you'll have to reinvent all of these types of custody when you want them to interoperate with this framework.  I would prefer a solution where this leverages the existing NFT state layer (or perhaps a slimmed down version, I have no objections there) and then makes a new type of custody which is similar to existing `p2_m_of_n` puzzles but which allows you to run some of the puzzles multiple times and in a specific order.

(there are some whitespace changes that are unintentional)